### PR TITLE
[Fix] Post author not being displayed on index

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,8 @@ title: Home
             {{ post.title }}
           </a>
         </h1> 
-        <span itemprop="name" class="post-meta">by <a href="{{ site.author.url }}">{{ site.author.name }}</a></span>             
+        {% assign author = site.data.authors[post.author] %}
+        <span itemprop="name" class="post-meta">by <a href="{{ author.url }}">{{ author.name }}</a></span>             
         {{ post.excerpt }}
       </div>
     </div>


### PR DESCRIPTION
The list of blog posts on index was displaying the website author instead of the post author.